### PR TITLE
Generalize object rotation

### DIFF
--- a/tests/geometric_tests.py
+++ b/tests/geometric_tests.py
@@ -7,6 +7,7 @@ import traceon.mesher as M
 from traceon.geometry import *
 import traceon.plotting as P
 
+
 class MeshTests(unittest.TestCase):
 
     def test_loading_mesh(self):
@@ -94,6 +95,33 @@ class PathTests(unittest.TestCase):
         assert np.allclose(y(sqrt(0)), origin)
         assert np.allclose(y(sqrt(2)), origin + np.array([0., 1., 1.]))
     
+    def test_rotate_around_axis(self):
+        
+        p = Path.line([0,0,0], [1,1,1])
+        origin=[0,0,0]
+        angle = pi/2
+        p_rot_par = p.rotate_around_axis([1,1,1], angle, origin)
+        assert np.allclose(p_rot_par.starting_point(), origin)
+        assert np.allclose(p_rot_par.endpoint(), np.array([1,1,1]))
+
+        p_rot_ort = p.rotate_around_axis([0,1,-1], angle, origin)
+        assert np.allclose(p_rot_ort.starting_point(), origin)
+        assert np.allclose(p_rot_ort.endpoint(), np.array([sqrt(2), -1/sqrt(2), -1/sqrt(2)]))
+
+        # general example calculated by hand using Rodrigues' formula as follows:
+        # Translate v to v' = v - origin. 
+        # Rotate around [0,0,0] using v_rot' = v'cos(theta) + (k \cross v')sin(theta) + (k(k\dot v))(1-cos(theta))
+        # Translate back to v_rot using v_rot = origin + v_rot'
+        origin = [2,1,-1]
+        p_rot_gen = p.rotate_around_axis([1,1,0], -pi/2, [2,1,-1])
+        assert np.allclose(p_rot_gen.starting_point(), np.array([-0.207107,0.207107,-1.707107]))
+        assert np.allclose(p_rot_gen.endpoint(), np.array([0.085786, 1.914214, -1.707107]))
+
+        # 2pi rotation should map object to itself
+        p_rot_2pi = p.rotate_around_axis([1,1,0], 2*pi, [2,1,-1])
+        assert np.allclose(p.starting_point(), p_rot_2pi.starting_point())
+        assert np.allclose(p.endpoint(), p_rot_2pi.endpoint())
+
     def test_discretize_path(self):
         path_length = 10 
         breakpoints = [3.33, 5., 9.]

--- a/traceon/mesher.py
+++ b/traceon/mesher.py
@@ -98,7 +98,6 @@ class GeometricObject(ABC):
     def rotate_around_axis(self, axis=[0., 0, 1.], angle=0., origin=[0., 0., 0.]):
         """
         Rotate  counterclockwise around a general axis defined by a vector.
-        If the normal points away, it rotates clockwise.
         
         Parameters
         ------------------------------------
@@ -122,14 +121,16 @@ class GeometricObject(ABC):
         axis = axis / np.linalg.norm(axis)
 
         if angle == 0:
-            return self
+            return self.map_points(lambda x: x)
         
+        # Rotation is implemented using Rodrigues' rotation formula
+        # See: https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
         K = np.array([
             [0, -axis[2], axis[1]],
             [axis[2], 0, -axis[0]],
             [-axis[1], axis[0], 0]])
         
-        K2 = K @ K
+        K2 = K @ K # Transformation matrix that maps a vector to its cross product with the rotation axis
         I = np.eye(3)
         R = I + np.sin(angle) * K + (1 - np.cos(angle)) * K2
 


### PR DESCRIPTION
added `rotate_around_axis`  for general object  rotation. I would be in favor of deprecating the `rotate` function and replacing it with this function. Thoughts?